### PR TITLE
Add bot server and webapp skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ To run tests use:
 ```bash
 npm test
 ```
+
+## Bot Development
+
+The server code lives in `server/` and uses Express together with Telegraf. To run the bot locally:
+
+```bash
+cd server
+npm install
+TELEGRAM_BOT_TOKEN=<your token> npm start
+```
+
+During production the bot uses webhooks. Set `RENDER_EXTERNAL_URL` to the deployed base URL and configure your Render service accordingly.

--- a/index.html
+++ b/index.html
@@ -1,17 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>TonPlaygram WebApp</title>
-<meta name="telegram:web_app:user_authorization" content="true">
-<meta name="telegram:web_app:bot_username" content="TonPlaygramBot">
-<link rel="icon" type="image/png" href="/assets/logo-tonplaygram.png">
-<link rel="stylesheet" href="/styles/globals.css">
-<link rel="stylesheet" href="/styles/theme.css">
-</head>
-<body>
-<div id="root"></div>
-<script type="module" src="/main.jsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TonPlaygram WebApp</title>
+    <meta name="telegram:web_app:user_authorization" content="true" />
+    <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
+    <link rel="icon" type="image/png" href="/assets/logo-tonplaygram.png" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.5.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,58 @@
+import 'dotenv/config';
+import express from 'express';
+import { Telegraf } from 'telegraf';
+
+const app = express();
+const botToken = process.env.TELEGRAM_BOT_TOKEN;
+
+if (!botToken) {
+  console.error('TELEGRAM_BOT_TOKEN is required');
+  process.exit(1);
+}
+
+const bot = new Telegraf(botToken);
+
+bot.start((ctx) => {
+  ctx.reply('🔥 TONPLAYGRAM BOT  |  Play. Earn. Dominate.', {
+    reply_markup: {
+      inline_keyboard: [
+        [{ text: '🚀 Launch WebApp', url: process.env.WEBAPP_URL || 'https://example.com' }],
+        [
+          { text: '🐦 Join Our Community', url: 'https://twitter.com/TonPlaygram' },
+          { text: '💬 Join Our Community', url: 'https://t.me/TonPlaygramChat' }
+        ]
+      ]
+    }
+  });
+});
+
+bot.command('mine', (ctx) => ctx.reply('Mining feature coming soon!'));
+bot.command('newdice', (ctx) => ctx.reply('Dice duel created!'));
+bot.command('newludo', (ctx) => ctx.reply('Ludo game created!'));
+bot.command('newhorse', (ctx) => ctx.reply('Horse racing room created!'));
+bot.command('newsnake', (ctx) => ctx.reply('Snake & Ladders room created!'));
+
+app.use(express.json());
+app.post(`/bot${botToken}`, (req, res) => {
+  bot.handleUpdate(req.body);
+  res.sendStatus(200);
+});
+
+app.get('/', (_req, res) => {
+  res.send('TonPlaygram Bot running');
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, async () => {
+  console.log(`Server listening on port ${port}`);
+  if (process.env.NODE_ENV === 'production') {
+    await bot.telegram.deleteWebhook();
+    const url = process.env.RENDER_EXTERNAL_URL || `https://example.com`;
+    await bot.telegram.setWebhook(`${url}/bot${botToken}`);
+  } else {
+    bot.launch();
+  }
+});
+
+process.once('SIGINT', () => bot.stop('SIGINT'));
+process.once('SIGTERM', () => bot.stop('SIGTERM'));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tonplaygram-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "telegraf": "^4.16.2"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,43 @@
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import Mining from './pages/Mining.jsx';
+import Games from './pages/Games.jsx';
+import Watch from './pages/Watch.jsx';
+import Tasks from './pages/Tasks.jsx';
+import Wallet from './pages/Wallet.jsx';
+import Referral from './pages/Referral.jsx';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <header className="flex items-center justify-between p-4 bg-gray-800 text-white">
+        <h1 className="text-lg font-bold">TonPlaygram</h1>
+        <a
+          href="https://t.me/TonPlaygramBot"
+          className="bg-primary px-4 py-2 rounded"
+        >
+          Launch Bot
+        </a>
+      </header>
+      <nav className="p-4 bg-gray-100 flex gap-2 text-sm">
+        <Link to="/mining">Mining</Link>
+        <Link to="/games">Games</Link>
+        <Link to="/watch">Watch</Link>
+        <Link to="/tasks">Tasks</Link>
+        <Link to="/wallet">Wallet</Link>
+        <Link to="/referral">Referral</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Mining />} />
+        <Route path="/mining" element={<Mining />} />
+        <Route path="/games" element={<Games />} />
+        <Route path="/watch" element={<Watch />} />
+        <Route path="/tasks" element={<Tasks />} />
+        <Route path="/wallet" element={<Wallet />} />
+        <Route path="/referral" element={<Referral />} />
+      </Routes>
+      <footer className="p-4 text-center text-xs text-gray-500">
+        © 2025 TonPlaygram. All rights reserved.
+      </footer>
+    </BrowserRouter>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root'))
-  .render(<h1>TonPlaygram MiniApp</h1>);
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Games.jsx
+++ b/src/pages/Games.jsx
@@ -1,0 +1,13 @@
+export default function Games() {
+  const games = ['Dice Duel', 'Ludo', 'Horse Racing', 'Snake & Ladders'];
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Games</h2>
+      <ul className="grid gap-2">
+        {games.map((g) => (
+          <li key={g} className="border p-2 rounded opacity-50">{g} (Coming Soon)</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Mining.jsx
+++ b/src/pages/Mining.jsx
@@ -1,0 +1,10 @@
+export default function Mining() {
+  return (
+    <div className="p-4 text-center">
+      <h2 className="text-xl font-bold mb-4">Mining</h2>
+      <button className="bg-primary text-white px-4 py-2 rounded" disabled>
+        Start Mining
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Referral.jsx
+++ b/src/pages/Referral.jsx
@@ -1,0 +1,13 @@
+export default function Referral() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Referral</h2>
+      <p>Your code: <strong>ABC123</strong></p>
+      <input
+        className="border p-2 w-full mt-2"
+        value="https://t.me/TonPlaygramBot?start=ABC123"
+        readOnly
+      />
+    </div>
+  );
+}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,0 +1,8 @@
+export default function Tasks() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Tasks</h2>
+      <p>No tasks available.</p>
+    </div>
+  );
+}

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -1,0 +1,17 @@
+export default function Wallet() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Wallet</h2>
+      <p>10,000 TPC</p>
+      <p>1.25 TON</p>
+      <div className="mt-4">
+        <button className="bg-primary text-white px-4 py-2 rounded mr-2" disabled>
+          Deposit TON
+        </button>
+        <button className="bg-primary text-white px-4 py-2 rounded" disabled>
+          Withdraw TPC
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Watch.jsx
+++ b/src/pages/Watch.jsx
@@ -1,0 +1,10 @@
+export default function Watch() {
+  return (
+    <div className="p-4 text-center">
+      <h2 className="text-xl font-bold mb-4">Watch to Earn</h2>
+      <button className="bg-primary text-white px-4 py-2 rounded" disabled>
+        Watch Now
+      </button>
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: '#0f62fe',
+        secondary: '#00d8ff',
+        accent: '#ffca28',
+      },
+    },
+  },
   plugins: [],
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({ plugins: [react()], root: './', build: { outDir: 'dist' } });
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- set up Express + Telegraf server with basic commands
- expand README with bot running instructions
- implement React router and pages (Mining, Games, Watch, Tasks, Wallet, Referral)
- setup Tailwind palette
- hook up new App component in main

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a1997aec8329a0443a55e31cd43d