### PR TITLE
Add start script and clarify deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ npm run dev
 
 This will start the Vite development server.
 
-To create a production build run:
+To create a production build and serve it run:
 
 ```bash
-npm run build
-npm run serve
+npm run build   # produces dist/
+npm start       # serves the built files
 ```
 
 Always access the app through the dev server or the preview server rather than opening `index.html` directly.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
+    "start": "node server/index.js",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a `start` script running the server
- document building and serving the app with `npm start`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68414286a5288329a7090d50a9f9348a